### PR TITLE
Add a --split output mode (one file per asset)

### DIFF
--- a/cmd/class-tree.go
+++ b/cmd/class-tree.go
@@ -56,16 +56,14 @@ var classTreeCmd = &cobra.Command{
 			}
 
 			p := parser.NewParser(file)
-			things, _ := p.ProcessPak(nil)
-
-			for _, thing := range things {
-				for _, export := range thing.Exports {
+			p.ProcessPak(nil, func(entry *parser.PakEntrySet, _ *parser.PakFile) {
+				for _, export := range entry.Exports {
 					open.WriteString(fmt.Sprintf("Class: %s%s\n", trim(export.Export.ObjectName), BuildClassTree(export.Export.ClassIndex)))
 					open.WriteString(fmt.Sprintf("Super: %s%s\n", trim(export.Export.ObjectName), BuildSuperTree(export.Export.SuperIndex)))
 					open.WriteString(fmt.Sprintf("Templ: %s%s\n", trim(export.Export.ObjectName), BuildTemplateTree(export.Export.TemplateIndex)))
 					open.WriteString(fmt.Sprintf("Outer: %s%s\n", trim(export.Export.ObjectName), BuildOuterTree(export.Export.OuterIndex)))
 				}
-			}
+			})
 
 			// indent, _ := json.MarshalIndent(concreteRecipe.Exports, "", " ")
 			// fmt.Println(string(indent))

--- a/cmd/class-tree.go
+++ b/cmd/class-tree.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/Vilsol/ue4pak/parser"
 	"github.com/fatih/color"
 	"github.com/gobwas/glob"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 func init() {

--- a/cmd/class-tree.go
+++ b/cmd/class-tree.go
@@ -56,7 +56,7 @@ var classTreeCmd = &cobra.Command{
 			}
 
 			p := parser.NewParser(file)
-			p.ProcessPak(nil, func(entry *parser.PakEntrySet, _ *parser.PakFile) {
+			p.ProcessPak(nil, func(_ string, entry *parser.PakEntrySet, _ *parser.PakFile) {
 				for _, export := range entry.Exports {
 					open.WriteString(fmt.Sprintf("Class: %s%s\n", trim(export.Export.ObjectName), BuildClassTree(export.Export.ClassIndex)))
 					open.WriteString(fmt.Sprintf("Super: %s%s\n", trim(export.Export.ObjectName), BuildSuperTree(export.Export.SuperIndex)))

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -71,26 +71,32 @@ var extractCmd = &cobra.Command{
 			})
 		}
 
-		var resultBytes []byte
-
-		if *format == "json" {
-			if *pretty {
-				resultBytes, err = json.MarshalIndent(results, "", "  ")
-			} else {
-				resultBytes, err = json.Marshal(results)
-			}
-
-			if err != nil {
-				panic(err)
-			}
-		} else {
-			panic("Unknown output format: " + *format)
-		}
-
+		resultBytes := formatResults(results)
 		err = ioutil.WriteFile(*output, resultBytes, 0644)
 
 		if err != nil {
 			panic(err)
 		}
 	},
+}
+
+func formatResults(result interface{}) []byte {
+	var resultBytes []byte
+	var err error
+
+	if *format == "json" {
+		if *pretty {
+			resultBytes, err = json.MarshalIndent(result, "", "  ")
+		} else {
+			resultBytes, err = json.Marshal(result)
+		}
+
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		panic("Unknown output format: " + *format)
+	}
+
+	return resultBytes
 }

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -55,8 +55,7 @@ var extractCmd = &cobra.Command{
 				panic(err)
 			}
 
-			p := parser.NewParser(file)
-			entrySets, _ := p.ProcessPak(func(name string) bool {
+			shouldProcess := func(name string) bool {
 				for _, pattern := range patterns {
 					if pattern.Match(name) {
 						return true
@@ -64,9 +63,12 @@ var extractCmd = &cobra.Command{
 				}
 
 				return false
-			})
+			}
 
-			results = append(results, entrySets...)
+			p := parser.NewParser(file)
+			p.ProcessPak(shouldProcess, func(entry *parser.PakEntrySet, _ *parser.PakFile) {
+				results = append(results, entry)
+			})
 		}
 
 		var resultBytes []byte

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Vilsol/ue4pak/parser"
 	"github.com/fatih/color"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gobwas/glob"
 	"github.com/spf13/cobra"
@@ -75,8 +76,12 @@ var extractCmd = &cobra.Command{
 						panic(err)
 					}
 
+					log.Infof("Writing Result: %s\n", destination)
 					resultBytes := formatResults(entry)
-					ioutil.WriteFile(destination, resultBytes, 0644)
+					err = ioutil.WriteFile(destination, resultBytes, 0644)
+					if err != nil {
+						panic(err)
+					}
 				} else {
 					results = append(results, entry)
 				}

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Vilsol/ue4pak/parser"
-	"github.com/fatih/color"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/Vilsol/ue4pak/parser"
+	"github.com/fatih/color"
 
 	"github.com/gobwas/glob"
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	_ "github.com/Vilsol/ue4pak/parser/games/satisfactory"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
 )
 
 var PakFile string

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -2,4 +2,5 @@ package cmd
 
 var format *string
 var output *string
+var split *bool
 var pretty *bool

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -38,7 +38,7 @@ var testCmd = &cobra.Command{
 			}
 
 			p := parser.NewParser(file)
-			p.ProcessPak(nil)
+			p.ProcessPak(nil, nil)
 			/*
 				f, err := os.OpenFile("dump.txt", os.O_WRONLY | os.O_CREATE, 0644)
 				fmt.Println(err)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/Vilsol/ue4pak/parser"
-	"github.com/fatih/color"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Vilsol/ue4pak/parser"
+	"github.com/fatih/color"
 
 	"github.com/spf13/cobra"
 )

--- a/parser/parser_types.go
+++ b/parser/parser_types.go
@@ -36,7 +36,7 @@ func NewParser(reader PakReader) *PakParser {
 	}
 }
 
-func (parser *PakParser) ProcessPak(parseFile func(string) bool, handleEntry func(*PakEntrySet, *PakFile)) {
+func (parser *PakParser) ProcessPak(parseFile func(string) bool, handleEntry func(string, *PakEntrySet, *PakFile)) {
 	pak := parser.Parse()
 
 	summaries := make(map[string]*FPackageFileSummary, 0)
@@ -95,7 +95,7 @@ func (parser *PakParser) ProcessPak(parseFile func(string) bool, handleEntry fun
 			}
 
 			if handleEntry != nil {
-				handleEntry(&PakEntrySet{
+				handleEntry(trimmed, &PakEntrySet{
 					ExportRecord: record,
 					Summary:      summary,
 					Exports:      exportSet,

--- a/parser/parser_types.go
+++ b/parser/parser_types.go
@@ -53,7 +53,7 @@ func (parser *PakParser) ProcessPak(parseFile func(string) bool, handleEntry fun
 
 		if strings.HasSuffix(trimmed, "uasset") {
 			offset := record.FileOffset + pak.Footer.HeaderSize()
-			log.Infof("Reading Record: %d [%x-%x]: %s\n", j, offset, offset+record.FileSize, trimmed)
+			log.Infof("Reading Summary: %d [%x-%x]: %s\n", j, offset, offset+record.FileSize, trimmed)
 			summaries[trimmed[0:strings.Index(trimmed, ".uasset")]] = record.ReadUAsset(pak, parser)
 			summaries[trimmed[0:strings.Index(trimmed, ".uasset")]].Record = record
 		}

--- a/parser/parser_types.go
+++ b/parser/parser_types.go
@@ -3,11 +3,12 @@ package parser
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
+	"strings"
+
 	"github.com/Vilsol/ue4pak/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"math"
-	"strings"
 )
 
 type PakParser struct {

--- a/parser/parser_types.go
+++ b/parser/parser_types.go
@@ -36,10 +36,8 @@ func NewParser(reader PakReader) *PakParser {
 	}
 }
 
-func (parser *PakParser) ProcessPak(parseFile func(string) bool) ([]*PakEntrySet, *PakFile) {
+func (parser *PakParser) ProcessPak(parseFile func(string) bool, handleEntry func(*PakEntrySet, *PakFile)) {
 	pak := parser.Parse()
-
-	results := make([]*PakEntrySet, 0)
 
 	summaries := make(map[string]*FPackageFileSummary, 0)
 
@@ -96,15 +94,15 @@ func (parser *PakParser) ProcessPak(parseFile func(string) bool) ([]*PakEntrySet
 				i++
 			}
 
-			results = append(results, &PakEntrySet{
-				ExportRecord: record,
-				Summary:      summary,
-				Exports:      exportSet,
-			})
+			if handleEntry != nil {
+				handleEntry(&PakEntrySet{
+					ExportRecord: record,
+					Summary:      summary,
+					Exports:      exportSet,
+				}, pak)
+			}
 		}
 	}
-
-	return results, pak
 }
 
 func (parser *PakParser) Parse() *PakFile {


### PR DESCRIPTION
Get a good perf boost from chunking the output (~3x faster on my box when extracting all the things), presumably due to less memory pressure & fewer GCs. 

Also helpful to break up output when dumping all the things